### PR TITLE
Fix rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ gem 'zipruby'
 gem 'rubocop'
 
 group :development, :test do
+  gem 'rspec'
   gem 'simplecov', require: false
   gem 'timecop'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,17 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
     byebug (8.2.2)
     chronic (0.10.2)
     coderay (1.1.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
     docile (1.1.5)
+    hashdiff (0.3.4)
     i18n (0.7.0)
     json (1.8.3)
     mail (2.6.3)
@@ -31,8 +37,22 @@ GEM
     pry-byebug (3.3.0)
       byebug (~> 8.0)
       pry (~> 0.10)
+    public_suffix (2.0.5)
     rainbow (2.1.0)
     rake (10.5.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
     rubocop (0.45.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
@@ -40,6 +60,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
+    safe_yaml (1.0.4)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -51,6 +72,10 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.1)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     whenever (0.9.4)
       chronic (>= 0.6.3)
     zipruby (0.3.6)
@@ -63,11 +88,13 @@ DEPENDENCIES
   pony
   pry-byebug
   rake
+  rspec
   rubocop
   simplecov
   timecop
+  webmock
   whenever
   zipruby
 
 BUNDLED WITH
-   1.13.6
+   1.15.1

--- a/Rakefile
+++ b/Rakefile
@@ -9,12 +9,8 @@ namespace :bojangles do
     Bojangles.go!
   end
   task :daily do
-    # Cache SAB stop ID
-
     # Cache the mapping from route number to Avail route ID
     Bojangles.cache_route_mappings!
     Bojangles.prepare!
-    # Cache departures
-    GtfsParser.prepare!
   end
 end

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
+  "stops": ["Studio Arts Building"],
   "mail_settings": {"to": "transit-it@admin.umass.edu",
                    "from": "transit-it@admin.umass.edu",
                    "subject": "PVTA realtime feed error"},

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,5 @@
 {
-  "stops": ["Studio Arts Building"],
+  "stops": ["Studio Arts Building", "Fine Arts Center", "Haigis Mall"],
   "mail_settings": {"to": "transit-it@admin.umass.edu",
                    "from": "transit-it@admin.umass.edu",
                    "subject": "PVTA realtime feed error"},

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 77.12
+    "covered_percent": 75.28
   }
 }

--- a/lib/bojangles.rb
+++ b/lib/bojangles.rb
@@ -142,7 +142,7 @@ module Bojangles
 
   def prepare!
     stops = CONFIG.fetch 'stops'
-    GtfsParser.prepare!(stops)
+    GtfsParser.prepare stops
   end
 
   def update_log_file!(to:)

--- a/lib/gtfs_parser.rb
+++ b/lib/gtfs_parser.rb
@@ -13,7 +13,7 @@ module GtfsParser
   GTFS_PATH = '/g_trans/google_transit.zip'
   LOG = File.expand_path('../../log', __FILE__)
 
-  def prepare!(stops)
+  def prepare(stops)
     zip_log_file!
     get_new_files! unless files_up_to_date?
     cache_departures!(stops)

--- a/spec/bojangles_spec.rb
+++ b/spec/bojangles_spec.rb
@@ -9,7 +9,7 @@ describe Bojangles do
       stub_request(:get, 'http://bustracker.pvta.com/InfoPoint/rest/stopdepartures/get/72')
         .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host' => 'bustracker.pvta.com', 'User-Agent' => 'Ruby' })
         .to_return(status: 200, body: '', headers: {})
-      Pony.stub(:deliver)
+      allow(Pony).to receive(:deliver)
     end
     context 'with new error messages' do
       it 'updates the log and caches error messages' do


### PR DESCRIPTION
Closes #34.

Don't need to call `GtfsParser.prepare` in the rake task. `Bojangles.prepare!` does this.

Updated the example `config.json` file to match what it needs to look like.

Fixed method name collision between the two `prepare!` methods. Was causing an `ArgumentError`.