### PR TITLE
Simplify the 'rake' job type

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,6 +2,8 @@
 
 env :PATH, ENV['PATH']
 
+job_type :rake, 'cd :path && bundle exec rake :task'
+
 # Every minute after 5am until 3am, check for departure inaccuracies.
 # Raw cron asterisk order: minute, hour, day of month, month, day of week
 every '* 0-2,5-23 * * *' do


### PR DESCRIPTION
Looked into this because I don't want the `--silent` flag,
but as I mentioned before I also see no reason `RAILS_ENV=production`
needs to be there either.