### PR TITLE
Only compare first two lines

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 67.87
+    "covered_percent": 68.44
   }
 }

--- a/lib/bojangles.rb
+++ b/lib/bojangles.rb
@@ -91,10 +91,10 @@ module Bojangles
   # that we've already sent it.
   def compare_errors(current_errors, old_errors)
     new_errors = current_errors.reject do |error|
-      old_errors.any?{|old| error.lines.first(2) == old.lines.first(2) }
+      old_errors.any? { |old| error.lines.first(2) == old.lines.first(2) }
     end
     resolved_errors = old_errors.reject do |error|
-      current_errors.any?{|new| error.lines.first(2) == new.lines.first(2) }
+      current_errors.any? { |new| error.lines.first(2) == new.lines.first(2) }
     end
     [new_errors, resolved_errors]
   end

--- a/spec/bojangles_spec.rb
+++ b/spec/bojangles_spec.rb
@@ -306,7 +306,7 @@ describe Bojangles do
     let(:message) { %w[apple banana cashew].join "\n" }
     let(:different_message) { %w[apple barley cashew].join "\n" }
     let(:equivalent_message) { %w[apple banana carrot].join "\n" }
-    
+
     let(:result) { Bojangles.compare_errors current, old }
     let(:current) { [message] }
     context 'messages differ by one of the first two lines' do

--- a/spec/bojangles_spec.rb
+++ b/spec/bojangles_spec.rb
@@ -301,4 +301,25 @@ describe Bojangles do
       end
     end
   end
+
+  describe 'compare_errors' do
+    let(:message) { %w[apple banana cashew].join "\n" }
+    let(:different_message) { %w[apple barley cashew].join "\n" }
+    let(:equivalent_message) { %w[apple banana carrot].join "\n" }
+    
+    let(:result) { Bojangles.compare_errors current, old }
+    let(:current) { [message] }
+    context 'messages differ by one of the first two lines' do
+      let(:old) { [different_message] }
+      it 'reports the difference' do
+        expect(result).to eql([[message], [different_message]])
+      end
+    end
+    context 'messages differ after the first two lines' do
+      let(:old) { [equivalent_message] }
+      it 'passes on by' do
+        expect(result).to eql([[], []]) # looks like an owl
+      end
+    end
+  end
 end


### PR DESCRIPTION
If the first two lines of an error message are the same, they're effectively the same error message. It's just a different departure on the same route direction is missing.