### PR TITLE
Only look at the first future departure

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 67.6
+    "covered_percent": 67.82
   }
 }

--- a/lib/bojangles.rb
+++ b/lib/bojangles.rb
@@ -60,7 +60,11 @@ module Bojangles
       route_directions.each do |route|
         route_id = route.fetch('RouteId').to_s
         route_number = cached_route_mappings[route_id]
-        departure = route.fetch('Departures').first
+        departure = route.fetch('Departures').select do |dep|
+          parse_json_unix_timestamp(dep.fetch 'SDT') >= Time.now
+        end.sort_by do |dep|
+          parse_json_unix_timestamp(dep.fetch 'SDT')
+        end.first
         next unless departure.present?
         departure_time = departure.fetch 'SDT' # scheduled departure time
         trip = departure.fetch 'Trip'

--- a/spec/bojangles_spec.rb
+++ b/spec/bojangles_spec.rb
@@ -197,7 +197,11 @@ describe Bojangles do
                 })
           .to_return(status: 200, body: response_body2, headers: {})
         Bojangles.cache_route_mappings!
-        result = Bojangles.get_avail_departure_times!([72, 79])
+
+        result = {}
+        Timecop.freeze Time.new(2016, 12, 12, 13, 55) do
+          result = Bojangles.get_avail_departure_times!([72, 79])
+        end
 
         expect(result).is_a? Hash
         expect(result).to include ['10', 'CompSci', 72] =>


### PR DESCRIPTION
The departures aren't necessarily in order, and may contain past departures (which have already occurred).