### PR TITLE
Keep different route directions

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 67.59
+    "covered_percent": 67.93
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 67.82
+    "covered_percent": 67.59
   }
 }

--- a/spec/bojangles_spec.rb
+++ b/spec/bojangles_spec.rb
@@ -172,9 +172,10 @@ describe Bojangles do
 
         dept1 = { SDT: '13:00', Trip: { InternetServiceDesc: 'Garage' } }
         dept2 = { SDT: '12:00', Trip: { InternetServiceDesc: 'CompSci' } }
+        dept3 = { SDT: '12:15', Trip: { InternetServiceDesc: 'CompSci' } }
         route_directions = [
           { ShortName: 30, RouteId: 20_030, Departures: [dept1] },
-          { ShortName: 10, RouteId: 20_010, Departures: [dept2] }
+          { ShortName: 10, RouteId: 20_010, Departures: [dept2, dept3] }
         ]
         response_body = [{ RouteDirections: route_directions }].to_json
         stub_request(:get, 'http://bustracker.pvta.com/InfoPoint/rest/stopdepartures/get/72')
@@ -184,9 +185,9 @@ describe Bojangles do
                   'User-Agent' => 'Ruby'
                 }).to_return(status: 200, body: response_body, headers: {})
 
-        dept3 = { SDT: '14:00', Trip: { InternetServiceDesc: 'LRC' } }
+        dept4 = { SDT: '14:00', Trip: { InternetServiceDesc: 'LRC' } }
         route_directions2 = [
-          { ShortName: 45, RouteId: 20_045, Departures: [dept3] }
+          { ShortName: 45, RouteId: 20_045, Departures: [dept4] }
         ]
         response_body2 = [{ RouteDirections: route_directions2 }].to_json
         stub_request(:get, 'http://bustracker.pvta.com/InfoPoint/rest/stopdepartures/get/79')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,13 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
+require 'json'
+require 'timecop'
 require 'rspec'
 require 'webmock/rspec'
 require_relative '../lib/bojangles'
+
+def json_unix_timestamp(*args)
+  timestamp = Time.new(*args).to_i
+  "/Date(#{timestamp}000-0400)/"
+end


### PR DESCRIPTION
The previous algorithm looked at only the earliest departure for a given route direction / stop combination. So if the 30 has two southbound departures at FAC, an 11:22 pm towards OBR and an 11:42 pm towards the Garage, bojangles would incorrectly report that the 11:42 pm departure was 'missing'.