### PR TITLE
Fix GTFS files never being fetched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 gtfs_files/**/*
+import_in_progress
 cached_departures.json
 cached_stops.json
 emailed_status.json

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,6 +18,5 @@ set :linked_files, fetch(:linked_files, []).push(
 )
 
 set :linked_dirs, fetch(:linked_dirs, []).push(
-  'gtfs',
   'log'
 )

--- a/lib/gtfs/files.rb
+++ b/lib/gtfs/files.rb
@@ -16,6 +16,7 @@ module GTFS
     def self.get_new!
       FileUtils.rm_rf LOCAL_GTFS_DIR
       FileUtils.mkdir_p LOCAL_GTFS_DIR
+      FileUtils.touch "#{LOCAL_GTFS_DIR}/.keep"
       gtfs_url = REMOTE_GTFS_PROTOCOL + REMOTE_GTFS_HOST + REMOTE_GTFS_PATH
       begin
         zipfile = Net::HTTP.get URI(gtfs_url)

--- a/lib/gtfs/files.rb
+++ b/lib/gtfs/files.rb
@@ -47,6 +47,7 @@ module GTFS
     # Is the remote GTFS archive more up-to-date than our cached files?
     def self.out_of_date?
       return false unless File.directory? LOCAL_GTFS_DIR
+      return true unless File.exists? "#{LOCAL_GTFS_DIR}/agency.txt"
       http = Net::HTTP.new REMOTE_GTFS_HOST
       begin
         response = http.head REMOTE_GTFS_PATH


### PR DESCRIPTION
Because the contents of the `gtfs_files` directory were gitignored, the directory was empty and would therefor not exist in the repo. Whenever the app was deployed, the daily task would break because `GTFS::Files.out_of_date?` would always return `false`