### PR TITLE
Make stop hastus_id a string

### DIFF
--- a/lib/models/departure.rb
+++ b/lib/models/departure.rb
@@ -29,7 +29,7 @@ class Departure < ActiveRecord::Base
     stops = Stop.pluck(:hastus_id, :id).to_h
     records.each do |data|
       data[:trip_id] = trips[data[:trip_id]]
-      data[:stop_id] = stops[data[:stop_id].to_i]
+      data[:stop_id] = stops[data[:stop_id]]
       where(data).first_or_create
     end
   end

--- a/lib/setup/database.rb
+++ b/lib/setup/database.rb
@@ -50,7 +50,7 @@ if ActiveRecord::Base.connection.tables.none? || ENV['REINITIALIZE']
 
     create_table :stops, force: true do |t|
       t.boolean :active, default: true
-      t.integer :hastus_id
+      t.string  :hastus_id
       t.string  :name
     end
 


### PR DESCRIPTION
This was necessitated by the current PVTA GTFS file

"Stop ID" was never guaranteed to be an integer in [the spec][1], ans at some point the export started containing parent stations with ids like "`place_UnSta`".

[1]: https://gtfs.org/reference/static/#stopstxt